### PR TITLE
fix: address PR #3 review findings

### DIFF
--- a/skills/vault-fetch/SKILL.md
+++ b/skills/vault-fetch/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: vault-fetch
+description: >
+  Webページを Playwright で取得し、Readability.js で記事本文を抽出して Markdown に変換するスキル。
+  以下の場面で使用すること:
+  (1) WebFetch が 403 エラーや Cloudflare チャレンジを返す場合
+  (2) JavaScript レンダリングが必要なサイトのコンテンツを取得したい場合
+  (3) ユーザーが「この URL を Obsidian に保存して」「記事をクリップして」と依頼した場合
+  (4) Web ページのクリーンな記事本文（広告・ナビゲーション除去済み）が必要な場合
+  headed-fetcher より高品質な抽出が可能（Readability.js による記事本文抽出 + Obsidian Clipper 互換フロントマター）。
+  ユーザーが URL のコンテンツ取得に困っている場合や、Obsidian・Vault・クリップ・保存といった言葉を使った場合にも積極的に使用すること。
+license: MIT
+compatibility:
+  - node
+  - playwright
+metadata:
+  version: 0.1.0
+  author: driller
+---
+
+# vault-fetch
+
+Web ページを Playwright で取得し、Readability.js で記事本文を抽出して Obsidian Clipper 互換の Markdown に変換するスキル。
+
+## When to Use
+
+- `WebFetch` ツールが 403 エラーを返す場合
+- Cloudflare などのボット対策が表示される場合
+- JavaScript を実行しないとコンテンツが表示されないサイト
+- ユーザーが Web ページを Obsidian Vault に保存したい場合
+- クリーンな記事本文（広告・ナビ除去済み）が必要な場合
+
+## Setup
+
+vault-fetch がグローバルインストールされていること:
+
+```bash
+npm install -g vault-fetch
+npx playwright install chromium
+```
+
+## Usage
+
+### Mode 1: コンテンツ取得（会話内で使用）
+
+ページの内容を取得して会話に返す場合は `--dry-run` を使う:
+
+```bash
+vault-fetch fetch <URL> --dry-run --dest /tmp
+```
+
+`--dry-run` は標準出力に Markdown を出力し、ファイル保存しない。`--dest` は必須引数だが `--dry-run` 時は実際には使われないので `/tmp` を指定する。
+
+### Mode 2: Obsidian Vault に保存
+
+ユーザーが「保存して」「クリップして」と言った場合:
+
+```bash
+vault-fetch fetch <URL> --dest ~/Documents/Obsidian/Clippings
+```
+
+保存先はユーザーに確認すること。設定ファイル (`~/.config/vault-fetch/config.yaml`) に `dest` が設定済みの場合は `--dest` を省略できる:
+
+```bash
+vault-fetch fetch <URL>
+```
+
+### Mode 3: 認証が必要なページ
+
+ログインが必要なサイトの場合、まずセッションを保存する:
+
+```bash
+vault-fetch login <URL>
+```
+
+ブラウザが開くので手動でログイン後、ターミナルで Enter を押す。以降の `fetch` でそのドメインのセッションが自動的に使用される。
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--dry-run` | ファイル保存せず標準出力に出力 |
+| `--dest <path>` | 保存先ディレクトリ |
+| `--selector <css>` | CSS セレクタで要素を抽出 |
+| `--headed` | headed モードで実行 |
+| `--timeout <sec>` | タイムアウト秒数（デフォルト: 30） |
+| `--tag <name>` | タグ追加（複数指定可） |
+| `--wait-until <event>` | 待機条件（デフォルト: networkidle） |
+| `--skip-session` | 保存済みセッションを使わない |
+
+## Output Format
+
+```yaml
+---
+title: Page Title
+source: https://example.com/article
+author:
+  - "[[Author Name]]"
+published: 2025-06-14
+created: 2025-07-03
+description: Article description...
+tags:
+  - clippings
+---
+
+Article content in Markdown...
+```
+
+## Error Handling
+
+| Error | Cause | Action |
+|-------|-------|--------|
+| `HTTP 4xx/5xx` | サーバーエラー | URL を確認、`--headed` で再試行 |
+| `Selector not found` | CSS セレクタが見つからない | セレクタを確認 |
+| `Timeout` | ページ読み込みが遅い | `--timeout` を増やす |
+| `dest is required` | 保存先未設定 | `--dest` を指定するか config.yaml を設定 |
+| 認証エラー・ログインページ表示 | セッション切れ | `vault-fetch login <URL>` でセッション更新 |
+
+## Tips
+
+- `--dry-run` は常に `--dest /tmp` と組み合わせる（`dest` は必須引数のため）
+- `--selector "article"` や `--selector ".post-content"` でメインコンテンツだけを抽出できる
+- `--headed` はデバッグやボット対策回避に有効

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,13 +33,44 @@ function expandTilde(filePath: string): string {
   return filePath;
 }
 
+const VALID_WAIT_UNTIL: readonly string[] = ["load", "domcontentloaded", "networkidle"];
+
+function validateWaitUntil(value: string): WaitUntilOption {
+  if (!VALID_WAIT_UNTIL.includes(value)) {
+    throw new Error(
+      `Invalid waitUntil value: "${value}". Must be one of: ${VALID_WAIT_UNTIL.join(", ")}`,
+    );
+  }
+  return value as WaitUntilOption;
+}
+
 function loadConfigFile(configPath: string): FileConfig {
   const content = readFileSync(configPath, "utf-8");
   const parsed = yaml.load(content);
   if (parsed === null || typeof parsed !== "object") {
     throw new Error(`Invalid config file: ${configPath}`);
   }
-  return parsed as FileConfig;
+  const config = parsed as Record<string, unknown>;
+
+  if (config.timeout !== undefined && typeof config.timeout !== "number") {
+    throw new Error(`Invalid timeout in config file: expected number, got ${typeof config.timeout}`);
+  }
+  if (config.dest !== undefined && typeof config.dest !== "string") {
+    throw new Error(`Invalid dest in config file: expected string, got ${typeof config.dest}`);
+  }
+  if (config.waitUntil !== undefined) {
+    if (typeof config.waitUntil !== "string") {
+      throw new Error(`Invalid waitUntil in config file: expected string, got ${typeof config.waitUntil}`);
+    }
+    validateWaitUntil(config.waitUntil);
+  }
+  if (config.tags !== undefined) {
+    if (!Array.isArray(config.tags) || !config.tags.every((t: unknown) => typeof t === "string")) {
+      throw new Error("Invalid tags in config file: expected array of strings");
+    }
+  }
+
+  return config as FileConfig;
 }
 
 export function resolveConfig(
@@ -77,8 +108,8 @@ export function resolveConfig(
     timeout = fileConfig.timeout ?? DEFAULT_TIMEOUT;
   }
 
-  const waitUntil =
-    cliOptions.waitUntil ?? fileConfig.waitUntil ?? DEFAULT_WAIT_UNTIL;
+  const rawWaitUntil = cliOptions.waitUntil ?? fileConfig.waitUntil ?? DEFAULT_WAIT_UNTIL;
+  const waitUntil = validateWaitUntil(rawWaitUntil);
 
   // Merge tags: file tags + CLI tags + always clippings
   const allTags = [

--- a/src/extractor.ts
+++ b/src/extractor.ts
@@ -63,56 +63,18 @@ export interface ExtractResult {
   content: string;
 }
 
-export function extract(html: string, finalUrl: string): ExtractResult {
-  // One JSDOM for metadata DOM queries
-  const metaDom = new JSDOM(html, { url: finalUrl });
-  const doc = metaDom.window.document;
-
-  // One JSDOM for Readability (which mutates the DOM)
-  const readabilityDom = new JSDOM(html, { url: finalUrl });
-  const reader = new Readability(readabilityDom.window.document);
-  const article = reader.parse();
-
-  if (!article) {
-    throw new Error("Readability failed to extract content from the page");
-  }
-
-  if (!article.content) {
-    throw new Error("Readability returned empty content for the page");
-  }
-
-  const title = article.title ?? doc.title;
-  const authors = extractAuthors(doc, article.byline ?? null);
-  const published = extractPublishedDate(doc);
-
-  const description =
-    getMetaContent(doc, 'meta[property="og:description"]') ??
-    getMetaContent(doc, 'meta[name="description"]') ??
-    (article.excerpt ?? null);
-
-  const today = new Date().toISOString().split("T")[0];
-
-  return {
-    metadata: {
-      title,
-      source: finalUrl,
-      author: authors,
-      published,
-      created: today,
-      description,
-    },
-    content: article.content,
-  };
+interface ReadabilityArticle {
+  title: string;
+  byline: string | null;
+  excerpt: string;
+  content: string;
 }
 
-export function extractMetadata(html: string, finalUrl: string): Metadata {
-  const metaDom = new JSDOM(html, { url: finalUrl });
-  const doc = metaDom.window.document;
-
-  const readabilityDom = new JSDOM(html, { url: finalUrl });
-  const reader = new Readability(readabilityDom.window.document);
-  const article = reader.parse();
-
+function buildMetadata(
+  doc: Document,
+  article: ReadabilityArticle | null,
+  finalUrl: string,
+): Metadata {
   const title = article?.title ?? doc.title;
   const authors = extractAuthors(doc, article?.byline ?? null);
   const published = extractPublishedDate(doc);
@@ -132,4 +94,39 @@ export function extractMetadata(html: string, finalUrl: string): Metadata {
     created: today,
     description,
   };
+}
+
+function parseWithReadability(html: string, url: string): ReadabilityArticle | null {
+  const dom = new JSDOM(html, { url });
+  const reader = new Readability(dom.window.document);
+  return reader.parse() as ReadabilityArticle | null;
+}
+
+export function extract(html: string, finalUrl: string): ExtractResult {
+  const metaDom = new JSDOM(html, { url: finalUrl });
+  const doc = metaDom.window.document;
+
+  const article = parseWithReadability(html, finalUrl);
+
+  if (!article) {
+    throw new Error("Readability failed to extract content from the page");
+  }
+
+  if (!article.content) {
+    throw new Error("Readability returned empty content for the page");
+  }
+
+  return {
+    metadata: buildMetadata(doc, article, finalUrl),
+    content: article.content,
+  };
+}
+
+export function extractMetadata(html: string, finalUrl: string): Metadata {
+  const metaDom = new JSDOM(html, { url: finalUrl });
+  const doc = metaDom.window.document;
+
+  const article = parseWithReadability(html, finalUrl);
+
+  return buildMetadata(doc, article, finalUrl);
 }

--- a/src/writer.ts
+++ b/src/writer.ts
@@ -4,10 +4,12 @@ import yaml from "js-yaml";
 import type { Metadata } from "./types.js";
 
 const UNSAFE_CHARS = /[/\\:*?"<>|]/g;
+const CONTROL_CHARS = /[\x00-\x1f\x7f]/g;
 const MAX_FILENAME_LENGTH = 200;
 
 export function sanitizeFilename(title: string): string {
   const sanitized = title
+    .replace(CONTROL_CHARS, "")
     .replace(UNSAFE_CHARS, "")
     .replace(/\s+/g, " ")
     .trim();

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -70,4 +70,29 @@ describe("resolveConfig", () => {
     expect(config.dest).not.toContain("~");
     expect(config.dest).toContain("Documents/Vault");
   });
+
+  it("throws on non-numeric VAULT_FETCH_TIMEOUT", () => {
+    process.env.VAULT_FETCH_TIMEOUT = "abc";
+    expect(() => resolveConfig({ dest: "/vault" }, undefined)).toThrow(
+      "Invalid VAULT_FETCH_TIMEOUT",
+    );
+  });
+
+  it("throws on invalid waitUntil value", () => {
+    expect(() =>
+      resolveConfig({ dest: "/vault", waitUntil: "invalid" as never }, undefined),
+    ).toThrow("Invalid waitUntil value");
+  });
+
+  it("throws on invalid timeout type in config file", () => {
+    const configPath = join(tmpDir, "config.yaml");
+    writeFileSync(configPath, "dest: /vault\ntimeout: not-a-number\n");
+    expect(() => resolveConfig({}, configPath)).toThrow("Invalid timeout in config file");
+  });
+
+  it("throws on invalid waitUntil in config file", () => {
+    const configPath = join(tmpDir, "config.yaml");
+    writeFileSync(configPath, "dest: /vault\nwaitUntil: invalid\n");
+    expect(() => resolveConfig({}, configPath)).toThrow("Invalid waitUntil value");
+  });
 });

--- a/tests/extractor.test.ts
+++ b/tests/extractor.test.ts
@@ -54,4 +54,14 @@ describe("extract", () => {
     expect(result.metadata.title).toBe("テスト記事タイトル");
     expect(result.content).toContain("テスト記事の本文");
   });
+
+  it("throws when Readability cannot parse content", () => {
+    expect(() => extract("", "https://example.com")).toThrow(
+      "Readability failed to extract content from the page",
+    );
+  });
+
+  it("throws when given completely empty HTML", () => {
+    expect(() => extract("<html><head></head><body></body></html>", "https://example.com")).toThrow();
+  });
 });


### PR DESCRIPTION
## Summary

- 制御文字（`\0`, `\n` 等）のファイル名サニタイズを追加
- `extract()` / `extractMetadata()` の重複ロジックを `buildMetadata()` ヘルパーに抽出
- 設定ファイル（YAML）のフィールド型バリデーション追加（timeout, dest, tags, waitUntil）
- `--wait-until` の値バリデーション追加（不正値で明確なエラー）
- Readability エラーパス・不正設定値のテスト追加（6 テスト追加、計 47 テスト）
- スキルを `skill/` → `skills/vault-fetch/` に移動（標準的な配置慣習に準拠）

## Test plan

- [x] 全 47 テスト PASS
- [x] 型チェック (`tsc --noEmit`) エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)