### PR TITLE
feat: add --field option for custom frontmatter injection

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@ import { once } from "node:events";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { resolveConfig, resolveProxy } from "./config.js";
+import { resolveConfig, resolveProxy, parseFields } from "./config.js";
 import { fetchPage } from "./fetcher.js";
 import { extract, extractMetadata } from "./extractor.js";
 import { convertToMarkdown } from "./converter.js";
@@ -49,6 +49,15 @@ program
   .option("--no-block-media", "Do not block media requests")
   .option("--raw", "Convert full page HTML without Readability extraction")
   .option("--title <text>", "Override the page title for the output filename")
+  .option(
+    "--field <kv>",
+    "Add custom frontmatter field key=value (repeatable)",
+    (val: string, acc: string[]) => {
+      acc.push(val);
+      return acc;
+    },
+    [] as string[],
+  )
   .option("--proxy <url>", "HTTP/HTTPS proxy URL (e.g. http://host:port)")
   .action(async (url: string, options: Record<string, unknown>) => {
     try {
@@ -69,6 +78,7 @@ program
           blockMedia: options.blockMedia as boolean | undefined,
           raw: options.raw as boolean | undefined,
           proxy: options.proxy as string | undefined,
+          fields: parseFields(options.field as string[]),
         },
         configPath,
       );
@@ -121,7 +131,7 @@ program
       }
 
       if (config.dryRun) {
-        const frontmatter = buildFrontmatter(metadata, config.tags);
+        const frontmatter = buildFrontmatter(metadata, config.tags, config.fields);
         process.stdout.write(`${frontmatter}\n\n${markdown}\n`);
       } else {
         const filePath = writeMarkdownFile(
@@ -129,6 +139,7 @@ program
           metadata,
           markdown,
           config.tags,
+          config.fields,
         );
         console.error(`Saved: ${filePath}`);
       }

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,9 @@ export function parseFields(raw: string[]): Record<string, unknown> {
     }
     const key = entry.slice(0, eq).trim();
     const rawValue = entry.slice(eq + 1);
+    if (key.length === 0) {
+      throw new Error(`Invalid --field "${entry}": key must not be empty`);
+    }
     if (
       (RESERVED_FRONTMATTER_KEYS as readonly string[]).includes(key)
     ) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,7 +30,8 @@ export function parseFields(raw: string[]): Record<string, unknown> {
       (RESERVED_FRONTMATTER_KEYS as readonly string[]).includes(key)
     ) {
       throw new Error(
-        `--field key "${key}" is reserved. Use the dedicated option instead (e.g. --title, --tag).`,
+        `--field key "${key}" is reserved. title/tags can be set via --title/--tag; ` +
+        `the others (source, author, published, created, description) are extracted automatically.`,
       );
     }
     result[key] = yaml.load(rawValue);

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,37 @@ import { resolve } from "node:path";
 import yaml from "js-yaml";
 import type { ResolvedConfig, WaitUntilOption } from "./types.js";
 
+export const RESERVED_FRONTMATTER_KEYS = [
+  "title",
+  "source",
+  "author",
+  "published",
+  "created",
+  "description",
+  "tags",
+] as const;
+
+export function parseFields(raw: string[]): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const entry of raw) {
+    const eq = entry.indexOf("=");
+    if (eq === -1) {
+      throw new Error(`Invalid --field "${entry}": expected key=value`);
+    }
+    const key = entry.slice(0, eq).trim();
+    const rawValue = entry.slice(eq + 1);
+    if (
+      (RESERVED_FRONTMATTER_KEYS as readonly string[]).includes(key)
+    ) {
+      throw new Error(
+        `--field key "${key}" is reserved. Use the dedicated option instead (e.g. --title, --tag).`,
+      );
+    }
+    result[key] = yaml.load(rawValue);
+  }
+  return result;
+}
+
 const DEFAULT_TIMEOUT = 30;
 const DEFAULT_WAIT_UNTIL: WaitUntilOption = "networkidle";
 const REQUIRED_TAG = "clippings";

--- a/src/config.ts
+++ b/src/config.ts
@@ -64,6 +64,7 @@ interface CliOptions {
   blockMedia?: boolean;
   raw?: boolean;
   proxy?: string;
+  fields?: Record<string, unknown>;
 }
 
 function expandTilde(filePath: string): string {
@@ -220,5 +221,6 @@ export function resolveConfig(
     blockMedia: cliOptions.blockMedia ?? true,
     raw: cliOptions.raw ?? false,
     proxy: resolveProxy(cliOptions.proxy, envProxy),
+    fields: cliOptions.fields ?? {},
   };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,17 +2,10 @@ import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { resolve } from "node:path";
 import yaml from "js-yaml";
+import { RESERVED_FRONTMATTER_KEYS } from "./types.js";
 import type { ResolvedConfig, WaitUntilOption } from "./types.js";
 
-export const RESERVED_FRONTMATTER_KEYS = [
-  "title",
-  "source",
-  "author",
-  "published",
-  "created",
-  "description",
-  "tags",
-] as const;
+export { RESERVED_FRONTMATTER_KEYS };
 
 export function parseFields(raw: string[]): Record<string, unknown> {
   const result: Record<string, unknown> = {};
@@ -33,6 +26,9 @@ export function parseFields(raw: string[]): Record<string, unknown> {
         `--field key "${key}" is reserved. title/tags can be set via --title/--tag; ` +
         `the others (source, author, published, created, description) are extracted automatically.`,
       );
+    }
+    if (key === "__proto__" || key === "constructor" || key === "prototype") {
+      throw new Error(`--field key "${key}" is not allowed`);
     }
     result[key] = yaml.load(rawValue);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,4 +41,5 @@ export interface ResolvedConfig {
   blockMedia: boolean;
   raw: boolean;
   proxy: string | null;
+  fields: Record<string, unknown>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,13 @@
+export const RESERVED_FRONTMATTER_KEYS = [
+  "title",
+  "source",
+  "author",
+  "published",
+  "created",
+  "description",
+  "tags",
+] as const;
+
 export interface Metadata {
   title: string;
   source: string;

--- a/src/writer.ts
+++ b/src/writer.ts
@@ -1,4 +1,4 @@
-import { writeFileSync } from "node:fs";
+import { writeFileSync, readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import yaml from "js-yaml";
 import type { Metadata } from "./types.js";
@@ -57,15 +57,52 @@ export function buildFrontmatter(
   return `---\n${yamlStr}---`;
 }
 
+function readSource(filePath: string): string | null {
+  if (!existsSync(filePath)) {
+    return null;
+  }
+  const content = readFileSync(filePath, "utf-8");
+  const match = content.match(/^source:\s*(.+)$/m);
+  return match ? match[1].trim() : null;
+}
+
+function resolveTargetPath(
+  dest: string,
+  baseFilename: string,
+  source: string,
+): string {
+  const ext = ".md";
+  const base = baseFilename.endsWith(ext)
+    ? baseFilename.slice(0, -ext.length)
+    : baseFilename;
+
+  let candidate = join(dest, `${base}${ext}`);
+  if (!existsSync(candidate)) {
+    return candidate;
+  }
+  if (readSource(candidate) === source) {
+    return candidate; // 同一ソース: 上書き
+  }
+  let n = 2;
+  for (;;) {
+    candidate = join(dest, `${base}-${n}${ext}`);
+    if (!existsSync(candidate) || readSource(candidate) === source) {
+      return candidate;
+    }
+    n += 1;
+  }
+}
+
 export function writeMarkdownFile(
   dest: string,
   metadata: Metadata,
   markdownContent: string,
   tags: string[],
+  fields: Record<string, unknown> = {},
 ): string {
   const filename = sanitizeFilename(metadata.title);
-  const filePath = join(dest, filename);
-  const frontmatter = buildFrontmatter(metadata, tags);
+  const filePath = resolveTargetPath(dest, filename, metadata.source);
+  const frontmatter = buildFrontmatter(metadata, tags, fields);
   const fullContent = `${frontmatter}\n\n${markdownContent}\n`;
 
   writeFileSync(filePath, fullContent, "utf-8");

--- a/src/writer.ts
+++ b/src/writer.ts
@@ -22,6 +22,8 @@ export function buildFrontmatter(
   tags: string[],
   fields: Record<string, unknown> = {},
 ): string {
+  // Fixed-schema keys: these MUST stay in sync with RESERVED_FRONTMATTER_KEYS in src/types.ts
+  // (title, source, author, published, created, description, tags)
   const data: Record<string, unknown> = {
     title: metadata.title,
     source: metadata.source,
@@ -70,7 +72,12 @@ function readSource(filePath: string): string | null {
     return null;
   }
   const frontmatter = content.slice(4, end);
-  const parsed = yaml.load(frontmatter);
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(frontmatter);
+  } catch {
+    return null;
+  }
   if (parsed === null || typeof parsed !== "object") {
     return null;
   }

--- a/src/writer.ts
+++ b/src/writer.ts
@@ -62,8 +62,20 @@ function readSource(filePath: string): string | null {
     return null;
   }
   const content = readFileSync(filePath, "utf-8");
-  const match = content.match(/^source:\s*(.+)$/m);
-  return match ? match[1].trim() : null;
+  if (!content.startsWith("---\n")) {
+    return null;
+  }
+  const end = content.indexOf("\n---", 4);
+  if (end === -1) {
+    return null;
+  }
+  const frontmatter = content.slice(4, end);
+  const parsed = yaml.load(frontmatter);
+  if (parsed === null || typeof parsed !== "object") {
+    return null;
+  }
+  const source = (parsed as Record<string, unknown>).source;
+  return typeof source === "string" ? source : null;
 }
 
 function resolveTargetPath(

--- a/src/writer.ts
+++ b/src/writer.ts
@@ -17,7 +17,11 @@ export function sanitizeFilename(title: string): string {
   return `${base}.md`;
 }
 
-export function buildFrontmatter(metadata: Metadata, tags: string[]): string {
+export function buildFrontmatter(
+  metadata: Metadata,
+  tags: string[],
+  fields: Record<string, unknown> = {},
+): string {
   const data: Record<string, unknown> = {
     title: metadata.title,
     source: metadata.source,
@@ -38,6 +42,10 @@ export function buildFrontmatter(metadata: Metadata, tags: string[]): string {
   }
 
   data.tags = tags;
+
+  for (const [key, value] of Object.entries(fields)) {
+    data[key] = value;
+  }
 
   const yamlStr = yaml.dump(data, {
     quotingType: '"',

--- a/tests/field.test.ts
+++ b/tests/field.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseFields, RESERVED_FRONTMATTER_KEYS } from "../src/config.js";
+import { parseFields, RESERVED_FRONTMATTER_KEYS, resolveConfig } from "../src/config.js";
 
 describe("parseFields", () => {
   it("parses simple key=value as string", () => {
@@ -39,5 +39,20 @@ describe("parseFields", () => {
     expect(RESERVED_FRONTMATTER_KEYS).toContain("title");
     expect(RESERVED_FRONTMATTER_KEYS).toContain("tags");
     expect(RESERVED_FRONTMATTER_KEYS).toContain("source");
+  });
+});
+
+describe("resolveConfig with fields", () => {
+  it("includes parsed fields in resolved config", () => {
+    const cfg = resolveConfig(
+      { dest: "/tmp", fields: { type: "clipping", ticker: ["[[AAPL]]"] } },
+      undefined,
+    );
+    expect(cfg.fields).toEqual({ type: "clipping", ticker: ["[[AAPL]]"] });
+  });
+
+  it("defaults fields to empty object when not given", () => {
+    const cfg = resolveConfig({ dest: "/tmp" }, undefined);
+    expect(cfg.fields).toEqual({});
   });
 });

--- a/tests/field.test.ts
+++ b/tests/field.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { parseFields, RESERVED_FRONTMATTER_KEYS, resolveConfig } from "../src/config.js";
+import { buildFrontmatter } from "../src/writer.js";
+import type { Metadata } from "../src/types.js";
 
 describe("parseFields", () => {
   it("parses simple key=value as string", () => {
@@ -54,5 +56,39 @@ describe("resolveConfig with fields", () => {
   it("defaults fields to empty object when not given", () => {
     const cfg = resolveConfig({ dest: "/tmp" }, undefined);
     expect(cfg.fields).toEqual({});
+  });
+});
+
+describe("buildFrontmatter with custom fields", () => {
+  const metadata: Metadata = {
+    title: "テスト記事",
+    source: "https://example.com",
+    author: [],
+    published: null,
+    created: "2026-06-01",
+    description: null,
+  };
+
+  it("appends custom fields after fixed schema", () => {
+    const fm = buildFrontmatter(metadata, ["clippings"], {
+      type: "clipping",
+      sentiment: "bullish",
+    });
+    expect(fm).toContain("type: clipping");
+    expect(fm).toContain("sentiment: bullish");
+  });
+
+  it("emits wikilink array values", () => {
+    const fm = buildFrontmatter(metadata, ["clippings"], {
+      ticker: ["[[AAPL]]"],
+    });
+    expect(fm).toContain("ticker:");
+    expect(fm).toContain("[[AAPL]]");
+  });
+
+  it("works when fields are omitted (backward compatible)", () => {
+    const fm = buildFrontmatter(metadata, ["clippings"]);
+    expect(fm).toMatch(/^---\n/);
+    expect(fm).toContain("title:");
   });
 });

--- a/tests/field.test.ts
+++ b/tests/field.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { parseFields, RESERVED_FRONTMATTER_KEYS } from "../src/config.js";
+
+describe("parseFields", () => {
+  it("parses simple key=value as string", () => {
+    expect(parseFields(["type=clipping"])).toEqual({ type: "clipping" });
+  });
+
+  it("parses YAML array value including wikilinks", () => {
+    expect(parseFields(['ticker=["[[AAPL]]"]'])).toEqual({
+      ticker: ["[[AAPL]]"],
+    });
+  });
+
+  it("parses multiple fields", () => {
+    expect(parseFields(["type=clipping", "sentiment=bullish"])).toEqual({
+      type: "clipping",
+      sentiment: "bullish",
+    });
+  });
+
+  it("keeps value after the first '=' intact", () => {
+    expect(parseFields(["note=a=b=c"])).toEqual({ note: "a=b=c" });
+  });
+
+  it("throws when '=' is missing", () => {
+    expect(() => parseFields(["broken"])).toThrow(/key=value/);
+  });
+
+  it("throws when key collides with a reserved frontmatter key", () => {
+    expect(() => parseFields(["title=X"])).toThrow(/reserved/i);
+  });
+
+  it("exposes the reserved key set", () => {
+    expect(RESERVED_FRONTMATTER_KEYS).toContain("title");
+    expect(RESERVED_FRONTMATTER_KEYS).toContain("tags");
+    expect(RESERVED_FRONTMATTER_KEYS).toContain("source");
+  });
+});

--- a/tests/field.test.ts
+++ b/tests/field.test.ts
@@ -27,6 +27,10 @@ describe("parseFields", () => {
     expect(() => parseFields(["broken"])).toThrow(/key=value/);
   });
 
+  it("throws when key is empty", () => {
+    expect(() => parseFields(["=value"])).toThrow(/empty/);
+  });
+
   it("throws when key collides with a reserved frontmatter key", () => {
     expect(() => parseFields(["title=X"])).toThrow(/reserved/i);
   });

--- a/tests/field.test.ts
+++ b/tests/field.test.ts
@@ -42,6 +42,38 @@ describe("parseFields", () => {
     expect(RESERVED_FRONTMATTER_KEYS).toContain("tags");
     expect(RESERVED_FRONTMATTER_KEYS).toContain("source");
   });
+
+  it("reserved key set contains all 7 fixed-schema keys (single-source guard)", () => {
+    const required = ["title", "source", "author", "published", "created", "description", "tags"];
+    for (const key of required) {
+      expect(RESERVED_FRONTMATTER_KEYS as readonly string[]).toContain(key);
+    }
+    expect(RESERVED_FRONTMATTER_KEYS).toHaveLength(7);
+  });
+
+  it("coerces numeric string to number via YAML parse", () => {
+    expect(parseFields(["n=5"])).toEqual({ n: 5 });
+  });
+
+  it("coerces null string to null via YAML parse", () => {
+    expect(parseFields(["x=null"])).toEqual({ x: null });
+  });
+
+  it("keeps plain string as string via YAML parse", () => {
+    expect(parseFields(["s=hello"])).toEqual({ s: "hello" });
+  });
+
+  it("rejects __proto__ key with an error", () => {
+    expect(() => parseFields(["__proto__=x"])).toThrow(/not allowed/);
+  });
+
+  it("rejects constructor key with an error", () => {
+    expect(() => parseFields(["constructor=x"])).toThrow(/not allowed/);
+  });
+
+  it("rejects prototype key with an error", () => {
+    expect(() => parseFields(["prototype=x"])).toThrow(/not allowed/);
+  });
 });
 
 describe("resolveConfig with fields", () => {
@@ -76,6 +108,9 @@ describe("buildFrontmatter with custom fields", () => {
     });
     expect(fm).toContain("type: clipping");
     expect(fm).toContain("sentiment: bullish");
+    // custom fields must come AFTER the fixed schema (tags is the last fixed key)
+    expect(fm.indexOf("type: clipping")).toBeGreaterThan(fm.indexOf("tags:"));
+    expect(fm.indexOf("sentiment: bullish")).toBeGreaterThan(fm.indexOf("tags:"));
   });
 
   it("emits wikilink array values", () => {

--- a/tests/filename-collision.test.ts
+++ b/tests/filename-collision.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { writeMarkdownFile } from "../src/writer.js";
-import { readFileSync, mkdirSync, rmSync, existsSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync, rmSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import type { Metadata } from "../src/types.js";
@@ -59,5 +59,20 @@ describe("writeMarkdownFile filename collision", () => {
     writeMarkdownFile(tmpDir, meta("https://b.com"), "B", ["clippings"]);
     const p3 = writeMarkdownFile(tmpDir, meta("https://c.com"), "C", ["clippings"]);
     expect(p3).toBe(join(tmpDir, "Same Title-3.md"));
+  });
+
+  it("does not throw when a neighboring file has malformed frontmatter and saves to -2", () => {
+    // Plant a neighbor with malformed frontmatter that causes yaml.load to throw
+    const neighborPath = join(tmpDir, "Same Title.md");
+    writeFileSync(neighborPath, "---\n: : : bad\n\ttab\n---\nsome content\n", "utf-8");
+
+    // Writing a new note with the same title but a valid source must NOT throw
+    // and must save to Same Title-2.md (malformed neighbor treated as "different source")
+    let result: string;
+    expect(() => {
+      result = writeMarkdownFile(tmpDir, meta("https://example.com"), "New Content", ["clippings"]);
+    }).not.toThrow();
+    expect(existsSync(join(tmpDir, "Same Title-2.md"))).toBe(true);
+    expect(result!).toBe(join(tmpDir, "Same Title-2.md"));
   });
 });

--- a/tests/filename-collision.test.ts
+++ b/tests/filename-collision.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { writeMarkdownFile } from "../src/writer.js";
+import { readFileSync, mkdirSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { Metadata } from "../src/types.js";
+
+function meta(source: string): Metadata {
+  return {
+    title: "Same Title",
+    source,
+    author: [],
+    published: null,
+    created: "2026-06-01",
+    description: null,
+  };
+}
+
+describe("writeMarkdownFile filename collision", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `vault-fetch-collision-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("writes a suffixed file when an existing file has a different source", () => {
+    const p1 = writeMarkdownFile(tmpDir, meta("https://a.com"), "A", ["clippings"]);
+    const p2 = writeMarkdownFile(tmpDir, meta("https://b.com"), "B", ["clippings"]);
+    expect(p1).toBe(join(tmpDir, "Same Title.md"));
+    expect(p2).toBe(join(tmpDir, "Same Title-2.md"));
+    expect(readFileSync(p1, "utf-8")).toContain("A");
+    expect(readFileSync(p2, "utf-8")).toContain("B");
+  });
+
+  it("overwrites when the existing file has the same source", () => {
+    const p1 = writeMarkdownFile(tmpDir, meta("https://a.com"), "First", ["clippings"]);
+    const p2 = writeMarkdownFile(tmpDir, meta("https://a.com"), "Second", ["clippings"]);
+    expect(p2).toBe(p1);
+    expect(readFileSync(p1, "utf-8")).toContain("Second");
+    expect(existsSync(join(tmpDir, "Same Title-2.md"))).toBe(false);
+  });
+
+  it("increments suffix across three different sources", () => {
+    writeMarkdownFile(tmpDir, meta("https://a.com"), "A", ["clippings"]);
+    writeMarkdownFile(tmpDir, meta("https://b.com"), "B", ["clippings"]);
+    const p3 = writeMarkdownFile(tmpDir, meta("https://c.com"), "C", ["clippings"]);
+    expect(p3).toBe(join(tmpDir, "Same Title-3.md"));
+  });
+});

--- a/tests/filename-collision.test.ts
+++ b/tests/filename-collision.test.ts
@@ -45,6 +45,15 @@ describe("writeMarkdownFile filename collision", () => {
     expect(existsSync(join(tmpDir, "Same Title-2.md"))).toBe(false);
   });
 
+  it("overwrites same source even when the URL gets YAML-quoted", () => {
+    const tricky = "https://example.com/search?q=react: hooks";
+    const p1 = writeMarkdownFile(tmpDir, meta(tricky), "First", ["clippings"]);
+    const p2 = writeMarkdownFile(tmpDir, meta(tricky), "Second", ["clippings"]);
+    expect(p2).toBe(p1);
+    expect(readFileSync(p1, "utf-8")).toContain("Second");
+    expect(existsSync(join(tmpDir, "Same Title-2.md"))).toBe(false);
+  });
+
   it("increments suffix across three different sources", () => {
     writeMarkdownFile(tmpDir, meta("https://a.com"), "A", ["clippings"]);
     writeMarkdownFile(tmpDir, meta("https://b.com"), "B", ["clippings"]);


### PR DESCRIPTION
## Summary

Adds a `--field key=value` option to the `fetch` command so callers can inject arbitrary frontmatter keys (e.g. `ticker`, `sentiment`, `source_type`) beyond the fixed schema. Also fixes a silent-overwrite bug in filename handling.

### `--field` (repeatable)
- `vault-fetch fetch <URL> --dest <dir> --field type=clipping --field 'ticker=["[[AAPL]]"]'`
- Values are parsed as YAML, so arrays/wikilinks work: `--field 'ticker=["[[AAPL]]"]'` renders as a proper YAML list.
- **Reserved-key guard**: the fixed schema keys (`title` / `source` / `author` / `published` / `created` / `description` / `tags`) are rejected with a clear error — use `--title` / `--tag` or rely on auto-extraction instead.
- Empty key (`=value`) is rejected.

### Filename collision fix
- Previously, two different articles with the same title silently overwrote each other.
- Now, when an existing file has a **different** `source`, the new file is saved under a numbered alias (`Title-2.md`, `Title-3.md`). Same `source` still overwrites (re-clipping the same article).
- `source` is read via YAML parse (not regex), fixing a quote-mismatch edge case with URLs containing `": "`.

## Test Plan
- [x] `npm test` — 126 tests pass (10 files)
- [x] `npm run typecheck` — clean
- [x] E2E: `--field` injects custom frontmatter in dry-run output
- [x] E2E: reserved key (`--field title=X`) rejected with non-zero exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)